### PR TITLE
feat(oneclickrecovery_cim_bootservice): add RequestStateChange message

### DIFF
--- a/src/cim/messages.test.ts
+++ b/src/cim/messages.test.ts
@@ -86,6 +86,12 @@ describe('CIM Tests', () => {
       const response = cimClass.BootService.SetBootConfigRole(bootSource, role)
       expect(response).toEqual(correctResponse)
     })
+    it('should create a valid cim_BootService RequestStateChange wsman message', () => {
+      const correctResponse = `${xmlHeader}${envelope}http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BootService/RequestStateChange</a:Action><a:To>/wsman</a:To><w:ResourceURI>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BootService</w:ResourceURI><a:MessageID>${(messageId++).toString()}</a:MessageID><a:ReplyTo><a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address></a:ReplyTo><w:OperationTimeout>${operationTimeout}</w:OperationTimeout></Header><Body><h:RequestStateChange_INPUT xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BootService"><h:RequestedState>3</h:RequestedState></h:RequestStateChange_INPUT></Body></Envelope>`
+      const response = cimClass.BootService.RequestStateChange(3)
+      expect(response).toEqual(correctResponse)
+    })
+
   })
   describe('cim_BootSourceSetting Tests', () => {
     it('should return a valid cim_BootSourceSetting Get wsman message', () => {

--- a/src/cim/messages.ts
+++ b/src/cim/messages.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
-import { Base, WSManMessageCreator } from '../WSMan'
-import { Classes, Actions } from './'
-import type { Types } from './'
 import type { Selector } from '../WSMan'
+import { Base, WSManMessageCreator } from '../WSMan'
+import type { Types } from './'
+import { Actions, Classes } from './'
 
 class BIOSElement extends Base {
   className = Classes.BIOS_ELEMENT
@@ -40,6 +40,17 @@ class BootService extends Base {
     const body = `<Body><h:SetBootConfigRole_INPUT xmlns:h="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BootService"><h:BootConfigSetting><Address xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.xmlsoap.org/ws/2004/08/addressing</Address><ReferenceParameters xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing"><ResourceURI xmlns="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_BootConfigSetting</ResourceURI><SelectorSet xmlns="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"><Selector Name="InstanceID">${bootSource}</Selector></SelectorSet></ReferenceParameters></h:BootConfigSetting><h:Role>${role}</h:Role></h:SetBootConfigRole_INPUT></Body>`
     return this.wsmanMessageCreator.createXml(header, body)
   }
+
+  /**
+   * Requests that the state of the element be changed to the value specified in the RequestedState parameter. When the requested state change takes place, the EnabledState and RequestedState of the element will be the same. Invoking the RequestStateChange method multiple times could result in earlier requests being overwritten or lost. If 0 is returned, then the task completed successfully and the use of ConcreteJob was not required. If 4096 (0x1000) is returned, then the task will take some time to complete, ConcreteJob will be created, and its reference returned in the output parameter Job. Any other return code indicates an error condition.
+   * @param requestedState The state requested for the element. This information will be placed into the RequestedState property of the instance if the return code of the RequestStateChange method is 0 ('Completed with No Error'), or 4096 (0x1000) ('Job Started'). Refer to the description of the EnabledState and RequestedState properties for the detailed explanations of the RequestedState values.
+   * @returns string
+   */
+  RequestStateChange = (requestedState: Types.BootService.RequestedState): string =>
+    this.protectedRequestStateChange(
+      `http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/${this.className}/RequestStateChange`,
+      requestedState
+    )
 }
 class BootSourceSetting extends Base {
   className = Classes.BOOT_SOURCE_SETTING

--- a/src/cim/types.ts
+++ b/src/cim/types.ts
@@ -684,6 +684,10 @@ export namespace Types {
      * IsNext:0 | IsNextSingleUse:1 | IsDefault:2
      */
     export type Role = 0 | 1 | 2
+    /**
+     * Enabled: 2 | Disabled: 3 | Shut Down: 4 | Offline: 6 | Test: 7 | Defer: 8 | Quiesce: 9 | Reboot: 10 | Reset: 11 | disable Intel One-Click Recovery and Intel RPE and enable all other boot options: 32768 | disable Intel RPE and enable Intel One-Click Recovery and all other boot options: 32769 | disable Intel One-Click Recovery and enable Intel RPE and all other boot options: 32770 | enable all boot options: 32771 | Vendor Reserved: 32772
+     */
+    export type RequestedState = 2 | 3 | 4 | 6 | 7 | 8 | 9 | 10 | 11 | 32768 | 32769 | 32770 | 32771 | 32772 
   }
 
   export namespace PowerManagementService {


### PR DESCRIPTION
## PR Checklist

- [Yes] Unit Tests have been added for new changes
- [Yes] All commented code has been removed
- [Yes] If you've added a dependency, you've ensured the license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?
It adds the RequestStateChange message for CIM > BootService, which is required for implementing One-Click Recovery.

## Anything the reviewer should know when reviewing this PR?
This method is one of the required to implement OCR. 
https://software.intel.com/sites/manageability/AMT_Implementation_and_Reference_Guide/default.htm?turl=WordDocuments%2Foneclickrecovery.htm

### If the there are associated PRs in other repositories, please link them here (i.e. open-amt-cloud-toolkit/repo#365 )
None