### PR TITLE
ci: update to latest codeql reporter

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       - name: Generate Security Report
-        uses: rsdmike/github-security-report-action@a149b24539044c92786ec39af8ba38c93496495d # v3.0.4
+        uses: rsdmike/github-security-report-action@1df22b1e0a7e15b32f728ccf7bab259e46c80589 # v4.0.1
         continue-on-error: true
         with:
           template: report


### PR DESCRIPTION
Updates `rsdmike/github-security-report-action` to v4.0.1, pinned to commit SHA `1df22b1e0a7e15b32f728ccf7bab259e46c80589`.